### PR TITLE
Compilation error fix

### DIFF
--- a/src/Internal/Compile/Frame.php
+++ b/src/Internal/Compile/Frame.php
@@ -262,20 +262,20 @@ class Frame {
      * @param int $n
      */
     private function popVarIDs($n) {
-        array_splice($this->var_ids, count($this->var_ids) - $n);
+        array_splice($this->var_ids, count($this->var_ids) - $n, $n);
     }
 
     /**
      * @param int $n
      */
     private function popVars($n) {
-        array_splice($this->vars, count($this->vars) - $n);
+        array_splice($this->vars, count($this->vars) - $n, $n);
     }
 
     /**
      * @param int $n
      */
     private function popDepths($n) {
-        array_splice($this->depths, count($this->depths) - $n);
+        array_splice($this->depths, count($this->depths) - $n, $n);
     }
 }

--- a/src/Internal/TemplateCache.php
+++ b/src/Internal/TemplateCache.php
@@ -78,7 +78,7 @@ class TemplateCache {
             $load_path_dir = dirname($dst->load_path);
             $load_path_basename = basename($dst->load_path);
             $cache_file_dir = $this->ctx->cache_dir . '/' . $load_path_dir;
-            if (KPHP_COMPILER_VERSION) {
+            if (defined('KPHP_COMPILER_VERSION')) {
                 $cache_filename = "$cache_file_dir/$load_path_basename.kphp.$dst->key_mtime.$dst->key_file_size.tdata";
             } else {
                 $cache_filename = "$cache_file_dir/$load_path_basename.php.$dst->key_mtime.$dst->key_file_size.tdata";


### PR DESCRIPTION
At the moment, when attempting to compile KTemplate, several errors occur:

1. Insufficient arguments when calling the array_splice function.
2. Error in using the constant KPHP_COMPILER_VERSION.

The PR addresses the locations where the errors occurred. Now KTemplate compiles and works without issues.